### PR TITLE
Updating wlcg-wpad for Python3 and EL9

### DIFF
--- a/misc/build-wlcg-wpad
+++ b/misc/build-wlcg-wpad
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Run this script from the parent directory of wlcg-wpad
+
+if [ $# != 0 ]; then
+    echo "No parameters accepted" >&2
+    exit 1
+fi
+
+mkdir -p RPMBUILD/SOURCES RPMBUILD/SPECS
+# Create a .macros file
+topDir=$(pwd)/RPMBUILD
+rpmmacrosDir=`pwd`
+rpmmacros=${rpmmacrosDir}/.rpmmacros
+test -f "${rpmmacros}" && mv -f ${rpmmacros} ${rpmmacros}_
+touch ${rpmmacros}
+echo "%_topdir ${topDir}">> ${rpmmacros}
+# gpg rpm signing related:
+echo "%_signature gpg">> ${rpmmacros}
+echo "%_gpg_name  cernFrontier">> ${rpmmacros}
+echo "%_gpg_path ${HOME}/.gnupg">> ${rpmmacros}
+echo "%_gpgbin /usr/bin/gpg">> ${rpmmacros}
+export HOME=${rpmmacrosDir}
+
+PKG=wlcg-wpad
+STARTDIR=`pwd`
+pushd ${PKG}
+# git pull
+SPECPATH=$PWD/rpm/${PKG}.spec
+SPECFILE=${SPECPATH##*/}
+set -ex
+VERSION="`sed -n 's/^Version: //p' $SPECPATH`"
+popd
+pushd RPMBUILD/SOURCES
+ln -fns ${STARTDIR}/${PKG} ${PKG}-$VERSION
+rm -f ${PKG}-$VERSION.tar.gz
+tar chvf ${PKG}-$VERSION.tar.gz --exclude .git ${PKG}-$VERSION
+rm -f ${PKG}-$VERSION
+popd
+#pushd RPMBUILD/RPMS/noarch
+# clean out all but last 2 rpm builds
+#ls ${PKG}-1*|head -n -2|cut -d. -f5|while read TS; do
+#    rm -f ${PKG}-*.$TS.*git*
+#done
+#popd
+
+rm -fr RPMBUILD/BU* RPMBUILD/SRPMS
+pushd RPMBUILD/SPECS
+#NOW="`date +%Y%m%d%H%M%S`"
+#RELEASE="0.0.$NOW.$LOGNAME.${GITREV}git"
+rm -f $SPECFILE
+#sed "s/^Release.*%/Release: $RELEASE%/" $SPECPATH >$SPECFILE
+cp $SPECPATH $SPECFILE
+set +x
+rpmbuild -ba $SPECFILE
+rpmsign --addsign ../RPMS/noarch/*.rpm

--- a/misc/wlcg-wpad.wsgi
+++ b/misc/wlcg-wpad.wsgi
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 import wpad_dispatch
 

--- a/pyweb/overload.py
+++ b/pyweb/overload.py
@@ -87,7 +87,7 @@ def orgload(remoteip, limit, minutes, persist, now):
     record = data.oldest
     while record != None and record.minute <= now - minutes:
         data.total -= record.requests
-        record = record.next
+        record = record.__next__
         data.oldest = record
     record = data.newest
     if record == None or record.minute != now:

--- a/pyweb/stashservers.py
+++ b/pyweb/stashservers.py
@@ -1,7 +1,7 @@
 # return the order of selected stashserver list followed by
 # the contents of stashservers.list
 
-import urllib2
+import urllib.request, urllib.parse, urllib.error
 
 stashserversfile = '/var/lib/wlcg-wpad/stashservers.whitelist'
 
@@ -24,7 +24,7 @@ def getbody(remoteip, parameters):
         raise Exception("list name '" + listname + "' unknown")
 
     url = 'http://localhost/api/v1.0/geo/' + remoteip + '/' + servers
-    request = urllib2.Request(url)
-    order = urllib2.urlopen(request).read()
+    request = urllib.Request(url)
+    order = urllib.request.urlopen(request).read()
 
     return order + contents

--- a/pyweb/wlcg_wpad.py
+++ b/pyweb/wlcg_wpad.py
@@ -3,7 +3,7 @@
 # Note: log messages that have a non-empty org (the third parameter to the
 #  logmsg function) are parsed for monitoring, up to a colon.
 
-import sys, os, copy, anyjson, netaddr, threading, time, socket
+import sys, os, copy, json, netaddr, threading, time, socket
 from wpad_utils import *
 import maxminddb
 
@@ -101,8 +101,8 @@ def updateorgs(host):
             handle = open(workerproxiesfile, 'r')
             jsondata = handle.read()
             handle.close()
-            workerproxies = anyjson.deserialize(jsondata)
-    except Exception, e:
+            workerproxies = json.loads(jsondata)
+    except Exception as e:
         logmsg(host, '-',  '', 'error reading ' + workerproxiesfile + ', using old: ' + str(e))
         orgsmodtime = 0
         neworgs = workerorgs
@@ -120,8 +120,8 @@ def updateorgs(host):
             handle = open(shoalsquidsfile, 'r')
             jsondata = handle.read()
             handle.close()
-            shoalsquids = anyjson.deserialize(jsondata)
-    except Exception, e:
+            shoalsquids = json.loads(jsondata)
+    except Exception as e:
         logmsg(host, '-',  '', 'error reading ' + shoalsquidsfile + ', using old: ' + str(e))
         shoalmodtime = 0
         if neworgs == workerorgs:

--- a/pyweb/wpad_utils.py
+++ b/pyweb/wpad_utils.py
@@ -1,4 +1,5 @@
 import os
 
 def logmsg(host, ip, org, msg):
-    print host + ' ' + ip + ' [' + str(org).encode('ISO-8859-1') + '] ' + msg
+    full_msg = host + ' ' + ip + ' [' + str(org) + '] ' + msg
+    print(full_msg.encode('ISO-8859-1'))

--- a/rpm/wlcg-wpad.spec
+++ b/rpm/wlcg-wpad.spec
@@ -1,6 +1,6 @@
 Summary: WLCG Web Proxy Auto Discovery
 Name: wlcg-wpad
-Version: 1.24
+Version: 1.25
 Release: 1%{?dist}
 BuildArch: noarch
 Group: Applications/System
@@ -11,7 +11,6 @@ Source0: https://frontier.cern.ch/dist/%{name}-%{version}.tar.gz
 Requires: httpd
 Requires: mod_wsgi
 Requires: cvmfs-server >= 2.7.1
-Requires: python-anyjson
 Requires: python-netaddr
 
 %description
@@ -56,7 +55,10 @@ fi
 
 
 %changelog
-* Mon Jan 02 2024 Dave Dykstra <dwd@fnal.gov> 1.24-1
+* Tue May 07 2024 Carl Vuosalo <cvuosalo@cern.ch> 1.25-1
+- Update for Python3 and EL9.
+
+* Tue Jan 02 2024 Dave Dykstra <dwd@fnal.gov> 1.24-1
 - Increase the max number of prefork apache processes from 256 to 1024.
 
 * Fri Dec 08 2023 Dave Dykstra <dwd@fnal.gov> 1.23-1

--- a/rpm/wlcg-wpad.spec
+++ b/rpm/wlcg-wpad.spec
@@ -9,9 +9,13 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Source0: https://frontier.cern.ch/dist/%{name}-%{version}.tar.gz
 
 Requires: httpd
+%if %{rhel} < 9
+Requires: python3-mod_wsgi
+%else
 Requires: mod_wsgi
+%endif
 Requires: cvmfs-server >= 2.7.1
-Requires: python-netaddr
+Requires: python3-netaddr
 
 %description
 Supplies Web Proxy Auto Discovery information for the Worldwide
@@ -55,8 +59,8 @@ fi
 
 
 %changelog
-* Tue May 07 2024 Carl Vuosalo <cvuosalo@cern.ch> 1.25-1
-- Update for Python3 and EL9.
+* Thu May 09 2024 Carl Vuosalo <cvuosalo@cern.ch> 1.25-1
+- Update for Python3, EL8, and EL9.
 
 * Tue Jan 02 2024 Dave Dykstra <dwd@fnal.gov> 1.24-1
 - Increase the max number of prefork apache processes from 256 to 1024.


### PR DESCRIPTION
The `wlcg-wpad` scripts were updated to support EL9 and converted to Python3. Also, the build script `build-wlcg-wpad` is being added.

These changes were tested by installing the RPM on an EL9 machine and sending it the query `curl -H Host:wlcg-wpad.fnal.gov http://vuosalox.hep.wisc.edu/wpad.dat`, which produced the correct output for choosing a proxy.