### PR TITLE
For Python3 conversion, another "encode" call is needed

### DIFF
--- a/pyweb/wpad_dispatch.py
+++ b/pyweb/wpad_dispatch.py
@@ -19,7 +19,7 @@ def error_request(start_response, response_code, response_body):
     start_response(response_code,
                    [('Cache-control', 'max-age=0'),
                     ('Content-Length', str(len(response_body)))])
-    return [response_body]
+    return [response_body.encode('utf-8')]
 
 def bad_request(start_response, host, ip, reason):
     response_body = 'Bad Request: ' + reason

--- a/rpm/wlcg-wpad.spec
+++ b/rpm/wlcg-wpad.spec
@@ -1,6 +1,6 @@
 Summary: WLCG Web Proxy Auto Discovery
 Name: wlcg-wpad
-Version: 1.25
+Version: 1.26
 Release: 1%{?dist}
 BuildArch: noarch
 Group: Applications/System
@@ -59,6 +59,9 @@ fi
 
 
 %changelog
+* Thu May 16 2024 Carl Vuosalo <cvuosalo@cern.ch> 1.26-1
+- Add one more "encode" for Python3 conversion.
+
 * Thu May 09 2024 Carl Vuosalo <cvuosalo@cern.ch> 1.25-1
 - Update for Python3, EL8, and EL9.
 


### PR DESCRIPTION
When the following calls to WPAD are made, exceptions are triggered:
```
curl  http://vuosalox.hep.wisc.edu/wpad.dat
curl -H Host:wlcg-wpad.fnal.gov http://vuosalox.hep.wisc.edu/wpad.dat?ip=71.201.128.241
```
The first one complains about an unrecognized host name, and the second says that no squid matches the IP address. However, these two exceptions were generating a general Python error because Python3 needs an `encode` for the error string.
This PR eliminates this Python error so the exceptions can be properly processed by the Python scripts. Tests verified that no more Python errors are being generated.

Inspection of the Python scripts didn't reveal any more remaining Python3 conversion issues, but it is possible some more are still lurking.